### PR TITLE
Add workflows

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,2 @@
+# nektos/act .actrc file
+-P ubuntu-latest=catthehacker/ubuntu:java-tools-latest

--- a/.github/workflows/update-sonarqube.yml
+++ b/.github/workflows/update-sonarqube.yml
@@ -1,0 +1,68 @@
+name: Refresh sonarqube spec
+on:
+  schedule:
+    - cron: "15 4 * * *"
+  workflow_dispatch:               
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.22.1'
+      - run: go version
+      - name: Check java found
+        id: check_java
+        run: |
+          if java --version; then
+              echo "installed=true" >> "$GITHUB_OUTPUT"
+              java --version
+          else
+              echo "installed=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Build
+        id: sonarqube_spec_build
+        run: |
+            go get
+            go build
+      - name: Run sonarqube-spec-json
+        id: sonarqube_spec_download_json
+        run: |
+            ./sonarqube-spec  -publicurl -outfile sonarqube-api.json -debug
+      # - name: Setup ACT Java
+      #   run: |
+      #     sudo apt update -y
+      #     sudo  apt install default-jre -y
+      #   if: ${{ env.ACT }}
+      - name: Install java
+        if: steps.check_java.outputs.installed == 'false' && ${{ env.ACT }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "11.x"
+      - uses: actions/setup-node@v4
+      - run: npm install @openapitools/openapi-generator-cli -g
+      - name: Run openapi-generator validate JSON
+        id: openapi_validate_json
+        run: |
+            openapi-generator-cli validate -i sonarqube-api.json
+      - name: Run openapi-generator-cli convert
+        id: openapi_convert
+        run: |
+          openapi-generator-cli generate -g openapi-yaml -i sonarqube-api.json --skip-overwrite --skip-validate-spec --skip-operation-example -o output
+          cp ./output/openapi/openapi.yaml sonarqube-api.yaml
+      - name: Commit files
+        id: commit_files
+        continue-on-error: true
+        run: |
+          git branch -v
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -a -m "Automatic updates to cloudflare"
+      - name: Push files
+        if: ${{ steps.commit_files.outcome == 'success' }}
+        run: |
+          git push --set-upstream origin autoupdate
+
+

--- a/.github/workflows/update-sonarqube.yml
+++ b/.github/workflows/update-sonarqube.yml
@@ -30,11 +30,6 @@ jobs:
         id: sonarqube_spec_download_json
         run: |
             ./sonarqube-spec  -publicurl -outfile sonarqube-api.json -debug
-      # - name: Setup ACT Java
-      #   run: |
-      #     sudo apt update -y
-      #     sudo  apt install default-jre -y
-      #   if: ${{ env.ACT }}
       - name: Install java
         if: steps.check_java.outputs.installed == 'false' && ${{ env.ACT }}
         uses: actions/setup-java@v4

--- a/.github/workflows/validate-sonarqube.yml
+++ b/.github/workflows/validate-sonarqube.yml
@@ -1,0 +1,23 @@
+name: Validate sonarqube spec
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**.json'
+      - '**.yaml'
+  workflow_dispatch:               
+jobs:
+    validate:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v4
+          - uses: actions/setup-node@v4
+          - run: npm install @openapitools/openapi-generator-cli -g
+          - name: Run openapi-generator validate YAML
+            id: openapi_validate_yaml
+            run: |
+                openapi-generator-cli validate -i sonarqube-api.yaml
+          - name: Run openapi-generator validate JSON
+            id: openapi_validate_json
+            run: |
+                openapi-generator-cli validate -i sonarqube-api.json


### PR DESCRIPTION
## What?
Added github actions to:
- validate the generate json/yaml specification files if a push on main occurs for those files
- schedule a retrieval&validation&push for the specification files against the public sonarqube

## Why?
The second should enable the creation of a regularly published and updated version of a kind of OpenAPi spec for sonarqube.

